### PR TITLE
Feat & Fix : 북마크, 좋아요 목록 통일 및 예외처리 확인 및 추가 / 로그아웃 구현 완료 / 좋,북,방 목록 페이지 구조 아주 조금 변경

### DIFF
--- a/catch-culture-frontend/package-lock.json
+++ b/catch-culture-frontend/package-lock.json
@@ -22,10 +22,11 @@
         "react-modal": "^3.16.1",
         "react-router-dom": "^6.20.0",
         "react-spinners": "^0.13.8",
-        "spinners": "^1.2.2",
         "react-toastify": "^9.1.3",
+        "spinners": "^1.2.2",
         "styled-components": "^6.1.0",
-        "swiper": "^11.0.3"
+        "swiper": "^11.0.3",
+        "toastify": "^2.0.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
@@ -3998,6 +3999,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toastify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/toastify/-/toastify-2.0.1.tgz",
+      "integrity": "sha512-Me/O93yAlwiHYwqX0su60Wv+X9ngzIT6nBLbNAFED095gMSjCBYKdu+faBxV6SE8CiQjUTBLrz8LwoXMtGz+yw=="
     },
     "node_modules/tslib": {
       "version": "2.6.2",

--- a/catch-culture-frontend/package.json
+++ b/catch-culture-frontend/package.json
@@ -24,10 +24,11 @@
     "react-modal": "^3.16.1",
     "react-router-dom": "^6.20.0",
     "react-spinners": "^0.13.8",
-    "spinners": "^1.2.2",
     "react-toastify": "^9.1.3",
+    "spinners": "^1.2.2",
     "styled-components": "^6.1.0",
-    "swiper": "^11.0.3"
+    "swiper": "^11.0.3",
+    "toastify": "^2.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",

--- a/catch-culture-frontend/src/pages/mypage/BookmarkList.css
+++ b/catch-culture-frontend/src/pages/mypage/BookmarkList.css
@@ -1,30 +1,27 @@
 .listall {
   display: flex;
-  position: relative;
   flex-direction: column;
-  gap: 68px;
+  gap: 25px;
   align-items: center;
 }
 
 .wrap {
   display: flex;
-  position: relative;
   flex-direction: column;
   width: 338px;
   padding-bottom: 20px;
 }
 
 .cateSel {
-  position: relative;
   display: flex;
 }
 
 .textrow {
   display: flex;
-  position: relative;
   align-items: baseline;
   gap: 8px;
-  padding-top: 16px;
+  justify-content: center;
+  padding-bottom: 20px;
 }
 .bookmarkCnt {
   font-size: 12px;
@@ -42,6 +39,7 @@
 .nors {
   display: flex;
   position: relative;
+  padding-top: 40px;
   width: 100%;
   justify-content: center;
 }

--- a/catch-culture-frontend/src/pages/mypage/BookmarkList.jsx
+++ b/catch-culture-frontend/src/pages/mypage/BookmarkList.jsx
@@ -48,15 +48,15 @@ function Bookmarks() {
     <div className="listall">
       <Backitem />
       <div className="wrap">
+        <div className="textrow">
+          <div className="liketext"> 북마크 목록 </div>
+          <div className="bookmarkCnt"> 총 {cnt}개 </div>
+        </div>
         <div className="cateSel">
           <CategorySelector
             selectedCategories={selectedCategories}
             setSelectedCategories={setSelectedCategories}
           />
-        </div>
-        <div className="textrow">
-          <div className="liketext"> 북마크 목록 </div>
-          <div className="bookmarkCnt"> 총 {cnt}개 </div>
         </div>
         <div className="eventlist">
           {cnt === 0 ? (

--- a/catch-culture-frontend/src/pages/mypage/BookmarkList.jsx
+++ b/catch-culture-frontend/src/pages/mypage/BookmarkList.jsx
@@ -11,34 +11,24 @@ import axios from '../../api/axios';
 function Bookmarks() {
   const { state } = useLocation();
   const category = state && state.category;
-
-  // state 값 유무에 따른 초기값 설정
   const initialCategories = category ? category : [];
-
-  // 카테고리 상태
   const [selectedCategories, setSelectedCategories] =
     useState(initialCategories);
 
-  // data
   const [data, setData] = useState([]);
-
-  // 임시 cnt
   const [cnt, setCnt] = useState(0);
   const offsetnum = 0;
 
-  // 카테고리 바뀔 때 마다 리렌더링
   useEffect(() => {
     fetchData();
   }, [selectedCategories]);
 
-  // 초기
   useEffect(() => {
     fetchData();
   }, []);
 
   const fetchData = async () => {
     try {
-      // URL 만들기 - 카테고리 선택
       const categoryUrl = selectedCategories
         .map((item) => 'category=' + item)
         .join('&');
@@ -47,13 +37,13 @@ function Bookmarks() {
         `/user/cultural-event?${categoryUrl}&offset=${offsetnum}&classification=STAR`
       );
 
-      // 데이터 저장
       setData(response.data.content);
       setCnt(response.data.numberOfElements);
     } catch (e) {
       console.log(e);
     }
   };
+
   return (
     <div className="listall">
       <Backitem />

--- a/catch-culture-frontend/src/pages/mypage/LikeList.jsx
+++ b/catch-culture-frontend/src/pages/mypage/LikeList.jsx
@@ -11,59 +11,34 @@ function Likes() {
   const { state } = useLocation();
   const [cnt, setCnt] = useState(0);
   const category = state && state.category;
-
-  // state 값 유무에 따른 초기값 설정
   const initialCategories = category ? category : [];
-
-  // 카테고리 상태
   const [selectedCategories, setSelectedCategories] =
     useState(initialCategories);
 
-  // data
   const [data, setData] = useState([]);
-  const [pagenum, setPageNum] = useState(0);
   const [dataList, setDataList] = useState([]);
-  const [pagecnt, setPagecnt] = useState(0);
-  const onScroll = () => {
-    if (pagecnt === 8) {
-      setPageNum(pagenum + 1);
-    }
-  };
+
   useEffect(() => {
-    window.addEventListener('scroll', onScroll);
-    window.addEventListener('touchmove', onScroll);
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-      window.removeEventListener('touchmove', onScroll);
-    };
+    fetchData();
+  }, [selectedCategories]);
+
+  useEffect(() => {
+    fetchData();
   }, []);
-
-  // 카테고리 바뀔 때 마다 리렌더링
-  useEffect(() => {
-    fetchData();
-  }, [selectedCategories, pagenum]);
-
-  // 초기
-  useEffect(() => {
-    fetchData();
-  }, [pagenum]);
 
   const fetchData = async () => {
     try {
-      // URL 만들기 - 카테고리 선택
       const categoryUrl = selectedCategories
         .map((item) => 'category=' + item)
         .join('&');
 
       const response = await axios.get(
-        `/user/cultural-event?${categoryUrl}&offset=${pagenum}&classification=LIKE`
+        `/user/cultural-event?${categoryUrl}&offset=0&classification=LIKE`
       );
 
-      // 데이터 저장
       setData(response.data.content);
       setCnt(response.data.totalElements);
       setDataList(dataList.concat(res.data.content));
-      setPagecnt(response.data.numberOfElements);
     } catch (e) {
       console.log(e);
     }

--- a/catch-culture-frontend/src/pages/mypage/LikeList.jsx
+++ b/catch-culture-frontend/src/pages/mypage/LikeList.jsx
@@ -48,15 +48,15 @@ function Likes() {
     <div className="listall">
       <Backitem />
       <div className="wrap">
+        <div className="textrow">
+          <div className="liketext">좋아요 목록</div>
+          <div className="bookmarkCnt">총 {cnt}개</div>
+        </div>
         <div className="cateSel">
           <CategorySelector
             selectedCategories={selectedCategories}
             setSelectedCategories={setSelectedCategories}
           />
-        </div>
-        <div className="textrow">
-          <div className="liketext">좋아요 목록</div>
-          <div className="bookmarkCnt">총 {cnt}개</div>
         </div>
         <div className="eventlist">
           {/* 문화 행사 출력 */}

--- a/catch-culture-frontend/src/pages/mypage/Mypage.jsx
+++ b/catch-culture-frontend/src/pages/mypage/Mypage.jsx
@@ -7,7 +7,6 @@ import {
   TbCoin,
   TbFileImport,
 } from 'react-icons/tb';
-
 import { NavLink } from 'react-router-dom';
 import './Mypage.css';
 import Level0 from '../../assets/pointimg/level0.png';
@@ -34,8 +33,13 @@ function Mypage() {
     fetchData();
   }, []);
 
-  console.log(nick);
-  console.log(img);
+  const fetchLogout = async () => {
+    try {
+      await axios.get(`/user/logout`);
+    } catch (e) {
+      console.log(e);
+    }
+  };
 
   return (
     <div className="mypageall">
@@ -50,7 +54,7 @@ function Mypage() {
                 <NavLink to="/profile-edit">
                   <button className="putprofile">개인정보 수정</button>
                 </NavLink>
-                <NavLink to="/">
+                <NavLink to="/" onClick={fetchLogout}>
                   <button className="logout">로그아웃</button>
                 </NavLink>
               </div>
@@ -67,7 +71,7 @@ function Mypage() {
               <NavLink to="/profile-edit">
                 <button className="putprofile">개인정보 수정</button>
               </NavLink>
-              <NavLink to="/">
+              <NavLink to="/" onClick={fetchLogout}>
                 <button className="logout">로그아웃</button>
               </NavLink>
             </div>

--- a/catch-culture-frontend/src/pages/mypage/PointLevel.jsx
+++ b/catch-culture-frontend/src/pages/mypage/PointLevel.jsx
@@ -4,7 +4,6 @@ import Level0 from '../../assets/pointimg/level0.png';
 import Level1 from '../../assets/pointimg/level1.png';
 import Level2 from '../../assets/pointimg/level2.png';
 import Level3 from '../../assets/pointimg/level3.png';
-import axios from '../../api/axios';
 import './PointLevel.css';
 
 function PointLevel() {

--- a/catch-culture-frontend/src/pages/mypage/ProfileDetail.jsx
+++ b/catch-culture-frontend/src/pages/mypage/ProfileDetail.jsx
@@ -12,7 +12,6 @@ function NickUpdate(props) {
       await axios.patch(`user/profile/nickname?nickName=${nick}`, {
         nickName: props.nick,
       });
-      console.log();
     } catch (e) {
       console.log(e);
     }
@@ -93,14 +92,6 @@ function ProfileEdit() {
     };
     fetchData();
   }, []);
-
-  // const nickPut = async () => {
-  //   try {
-  //     await axios.patch(`user/profile/nickname`, { nickname: { nick } });
-  //   } catch (e) {
-  //     console.log(e);
-  //   }
-  // };
 
   return (
     <div className="allcontents">

--- a/catch-culture-frontend/src/pages/mypage/ReportList.jsx
+++ b/catch-culture-frontend/src/pages/mypage/ReportList.jsx
@@ -48,11 +48,15 @@ function ReportList() {
   }, [data]);
 
   const fetchData = async () => {
-    const res = await axios.get(`/user/my-reports?page=${pagenum}&size=8`);
-    setCnt(res.data.totalElements);
-    setData(res.data.content);
-    setDataList(dataList.concat(res.data.content));
-    setLast(res.data.last);
+    try {
+      const res = await axios.get(`/user/my-reports?page=${pagenum}&size=8`);
+      setCnt(res.data.totalElements);
+      setData(res.data.content);
+      setDataList(dataList.concat(res.data.content));
+      setLast(res.data.last);
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   useEffect(() => {

--- a/catch-culture-frontend/src/pages/mypage/Reviews.css
+++ b/catch-culture-frontend/src/pages/mypage/Reviews.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  gap: 60px;
+  gap: 25px;
 }
 .reviewwrap {
   width: 320px;
@@ -12,7 +12,8 @@
   display: flex;
   gap: 8px;
   align-items: baseline;
-  padding-bottom: 12px;
+  justify-content: center;
+  padding-bottom: 24px;
 }
 .reviewtext {
   font-size: 20px;

--- a/catch-culture-frontend/src/pages/mypage/Reviews.jsx
+++ b/catch-culture-frontend/src/pages/mypage/Reviews.jsx
@@ -112,10 +112,14 @@ function Reviews() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const res = await axios.get(`/user/my-reviews?page=${pagenum}&size=5`);
-      setCnt(res.data.totalElements);
-      setData(res.data.content);
-      setDataList(dataList.concat(res.data.content));
+      try {
+        const res = await axios.get(`/user/my-reviews?page=${pagenum}&size=5`);
+        setCnt(res.data.totalElements);
+        setData(res.data.content);
+        setDataList(dataList.concat(res.data.content));
+      } catch (e) {
+        console.log(e);
+      }
     };
     fetchData();
   }, [pagenum]);

--- a/catch-culture-frontend/src/pages/mypage/Visited.jsx
+++ b/catch-culture-frontend/src/pages/mypage/Visited.jsx
@@ -46,15 +46,15 @@ function Visited() {
     <div className="listall">
       <Backitem />
       <div className="wrap">
+        <div className="textrow">
+          <div className="liketext">방문 내역</div>
+          <div className="bookmarkCnt">총 {cnt}개</div>
+        </div>
         <div className="cateSel">
           <CategorySelector
             selectedCategories={selectedCategories}
             setSelectedCategories={setSelectedCategories}
           />
-        </div>
-        <div className="textrow">
-          <div className="liketext">방문 내역</div>
-          <div className="bookmarkCnt">총 {cnt}개</div>
         </div>
         <div className="eventlist">
           {/* 문화 행사 출력 */}

--- a/catch-culture-frontend/src/pages/mypage/Visited.jsx
+++ b/catch-culture-frontend/src/pages/mypage/Visited.jsx
@@ -11,40 +11,30 @@ function Visited() {
   const { state } = useLocation();
   const category = state && state.category;
   const [cnt, setCnt] = useState(0);
-  const offsetnum = 0;
-
-  // state 값 유무에 따른 초기값 설정
   const initialCategories = category ? category : [];
-
-  // 카테고리 상태
   const [selectedCategories, setSelectedCategories] =
     useState(initialCategories);
 
   // data
   const [data, setData] = useState([]);
 
-  // 카테고리 바뀔 때 마다 리렌더링
   useEffect(() => {
     fetchData();
   }, [selectedCategories]);
 
-  // 초기
   useEffect(() => {
     fetchData();
   }, []);
 
   const fetchData = async () => {
     try {
-      // URL 만들기 - 카테고리 선택
       const categoryUrl = selectedCategories
         .map((item) => 'category=' + item)
         .join('&');
 
       const response = await axios.get(
-        `user/cultural-event?${categoryUrl}&offset=${offsetnum}&classification=VISIT_AUTH`
-      ); //api 짜는 대로 다시 불러오기
-
-      // 데이터 저장
+        `user/cultural-event?${categoryUrl}&offset=0&classification=VISIT_AUTH`
+      );
       setData(response.data.content);
       setCnt(response.data.totalElements);
     } catch (e) {


### PR DESCRIPTION
+ api 호출 시 필요한 try, catch 예외처리 작성 안 된 곳 추가 작성
+ 북마크, 좋아요 목록 그냥 스크롤 없이 데이터 전체 불러와져서 스크롤 코드 작성한 거 빼고 통일시킴
+ 갑자기 닉네임 수정 부분에서 내내 잘 되던 게 서버 500 오류 뜨는데 왜 그러는지 모르겠음 -> 명우가 해결해준대
+ 로그아웃 api가 방금 생겼길래 구현 예정 -> 해결함
======================
위 아래 다른 커밋 ㅇㅇ pr을 한 번에 올릴 뿐
+ 로그아웃 구현 완료
+ 좋아요 목록 안내 텍스트를 카테고리 바 위로 보내고 가운데 정렬함